### PR TITLE
README: Fix flag name in example

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ If you want to save the output to a file, use
 If you use the filename "-", CSSTidy reads from stdin.
 To change settings, you have to add "--thesettingyouwanttochange=true or false" after the input file. If "true" is first in the syntax description, this indicates that "true" is the default value (the same applies to false). Example:
 
-    csstidy mycssfile.css --remove_last_;=true myoutputfile.css
+    csstidy mycssfile.css --remove_last_semicolon=true myoutputfile.css
 
 
 ## Original Description


### PR DESCRIPTION
The example command line in the README was still using `remove-last-;`, the old name for `remove-last_semicolon`. (And a semicolon placed there on the command line would break the command into two separate, invalid ones, in any UNIX-like terminal shell.)