### PR TITLE
Include what we use

### DIFF
--- a/csstidy/background.cpp
+++ b/csstidy/background.cpp
@@ -17,7 +17,20 @@
  *   along with this program.  If not, see <http://www.gnu.org/licenses/>.
 */
  
-#include "csspp_globals.hpp"
+#include <ctype.h>             // for isdigit
+#include <algorithm>           // for max
+#include <iosfwd>              // for std
+#include <map>                 // for map, map<>::mapped_type, _Rb_tree_iter...
+#include <memory>              // for allocator, allocator_traits<>::value_type
+#include <string>              // for string, basic_string, operator<, opera...
+#include <utility>             // for pair
+#include <vector>              // for vector
+#include "background.hpp"      // for dissolve_short_bg, explode_ws, merge_bg
+#include "important.hpp"       // for gvw_important, is_important
+#include "misc.hpp"            // for in_str_array, escaped
+#include "trim.hpp"            // for trim
+#include "umap.hpp"            // for umap
+
 using namespace std;
 extern map<string,string> background_prop_default;
 

--- a/csstidy/background.hpp
+++ b/csstidy/background.hpp
@@ -20,12 +20,17 @@
 #ifndef HEADER_CSS_BACKGROUND
 #define HEADER_CSS_BACKGROUND 
 
+#include <map>     // for map
+#include <string>  // for string
+#include <vector>  // for vector
+template <class keyT, class valT> class umap;
+
 // Dissolves the background property
-map<string,string> dissolve_short_bg(const string istring);
+std::map<std::string,std::string> dissolve_short_bg(const std::string istring);
 
 // Same as explode, but not within a string
-vector<string> explode_ws(char sep,string istring);
+std::vector<std::string> explode_ws(char sep, std::string istring);
 
-void merge_bg(umap<string,string>& css_input);
+void merge_bg(umap<std::string,std::string>& css_input);
 
 #endif // HEADER_CSS_BACKGROUND

--- a/csstidy/conversions.cpp
+++ b/csstidy/conversions.cpp
@@ -16,8 +16,16 @@
  *   You should have received a copy of the GNU Lesser General Public License
  *   along with this program.  If not, see <http://www.gnu.org/licenses/>.
 */
- 
-#include "csspp_globals.hpp"
+
+#include "conversions.hpp"
+#include <ctype.h>   // for tolower
+#include <stdlib.h>  // for atof
+#include <cmath>     // for pow
+#include <sstream>   // for stringstream, basic_ostream, basic_ostream::oper...
+#include <string>    // for string, char_traits
+#include "trim.hpp"  // for trim
+
+using namespace std;
 
 string strtolower(string istring)
 {
@@ -141,7 +149,7 @@ double hexdec(string istring)
 			case '9': num = 9; break;
 			case '0': num = 0; break;
 		}
-		ret += num*pow((double) 16, (double) istring.length()-i-1);
+		ret += num * std::pow((double) 16, (double) istring.length()-i-1);
 	}
 	return ret;
 }

--- a/csstidy/conversions.hpp
+++ b/csstidy/conversions.hpp
@@ -20,28 +20,30 @@
 #ifndef HEADER_CSS_CONVERT
 #define HEADER_CSS_CONVERT 
 
+#include <string>  // for string
+
 // Returns the lowercase version of a string
-string strtolower(string istring);
+std::string strtolower(std::string istring);
 // Apparently faster replacement for tolower
 char chartolower(const char c);
 
 // Returns the uppercase version of a string
-string strtoupper(string istring);
+std::string strtoupper(std::string istring);
 char chartoupper(const char c);
 
 // Converts an integer to a hex-string
-string dechex(const int i);
+std::string dechex(const int i);
 
 // Converts a hexadecimal number (string) to a decimal number
-double hexdec(string istring);
+double hexdec(std::string istring);
 
 // Converts float to string
-string f2str(const float f);
+std::string f2str(const float f);
 
 // Converts a string to float
-float str2f(const string istring);
+float str2f(const std::string istring);
 
 // Converts a char to a string
-string char2str(const char c);
+std::string char2str(const char c);
 
 #endif // HEADER_CSS_CONVERT

--- a/csstidy/cssopt.cpp
+++ b/csstidy/cssopt.cpp
@@ -17,7 +17,22 @@
  *   along with this program.  If not, see <http://www.gnu.org/licenses/>.
 */
  
-#include "csspp_globals.hpp"
+#include <math.h>              // for abs
+#include <stdlib.h>            // for atoi, abs
+#include <iosfwd>              // for std
+#include <map>                 // for _Rb_tree_iterator, map
+#include <memory>              // for allocator, allocator_traits<>::value_type
+#include <string>              // for string, operator==, basic_string, oper...
+#include <utility>             // for pair
+#include <vector>              // for vector
+#include "conversions.hpp"     // for str2f, strtolower, f2str, dechex, strt...
+#include "cssopt.hpp"          // for c_font_weight, compress_numbers, cut_c...
+#include "datastruct.hpp"      // for sstore
+#include "important.hpp"       // for gvw_important, is_important
+#include "misc.hpp"            // for explode, ctype_digit, in_str_array, round
+#include "trim.hpp"            // for trim
+#include "umap.hpp"            // for umap<>::iterator, umap
+
 using namespace std;
 
 extern vector<string> unit_values,color_values;

--- a/csstidy/cssopt.hpp
+++ b/csstidy/cssopt.hpp
@@ -18,22 +18,25 @@
 */
  
 #ifndef HEADER_CSS_OPT
-#define HEADER_CSS_OPT 
+#define HEADER_CSS_OPT
+
+#include <string>          // for string
+#include "datastruct.hpp"  // for sstore
 
 // Color compression function. Converts all rgb() values to #-values and uses the short-form if possible. Also replaces color names and codes.
-string cut_color(string color);
+std::string cut_color(std::string color);
 
 // Compresses shorthand values. Example: margin:1px 1px 1px 1px -> margin:1px
-string shorthand(string value);
+std::string shorthand(std::string value);
 
 // Compresses numbers (ie. 1.0 -> 1 or 1.100 -> 1.1 
-string compress_numbers(string subvalue, string property = "", string function = "");
+std::string compress_numbers(std::string subvalue, std::string property = "", std::string function = "");
 
 // Checks if the next word in a string from pos is a CSS property
-bool property_is_next(string istring, const int pos);
+bool property_is_next(std::string istring, const int pos);
 
 // Compress font-weight
-int c_font_weight(string& value);
+int c_font_weight(std::string& value);
 
 // Merges selectors which have the same properties
 void merge_selectors(sstore& input);

--- a/csstidy/csspp_globals.hpp
+++ b/csstidy/csspp_globals.hpp
@@ -16,32 +16,10 @@
  *   You should have received a copy of the GNU Lesser General Public License
  *   along with this program.  If not, see <http://www.gnu.org/licenses/>.
 */
- 
+
+#ifndef HEADER_CSS_GLOBALS
+#define HEADER_CSS_GLOBALS
+
 #define CSSTIDY_VERSION "1.3"
-#include <cstdlib>
-#include <string> 
-#include <iterator>
-#include <vector>
-#include <assert.h>
-#include <math.h>
-#include <time.h>
-#include <sstream>
-#include <iostream>
-#include <fstream>
-#include <map>
-#include <algorithm>
 
-#include "umap.hpp"
-#include "datastruct.hpp"
-
-#include "trim.hpp"
-#include "conversions.hpp"
-#include "misc.hpp"
-#include "important.hpp"
-#include "file_functions.hpp"
-
-#include "cssopt.hpp"
-#include "csstidy.hpp"
-
-#include "parse_css.hpp"
-#include "background.hpp"
+#endif  // HEADER_CSS_GLOBALS

--- a/csstidy/csstidy.cpp
+++ b/csstidy/csstidy.cpp
@@ -17,7 +17,23 @@
  *   along with this program.  If not, see <http://www.gnu.org/licenses/>.
 */
  
-#include "csspp_globals.hpp"
+#include "csstidy.hpp"
+#include <fstream>          // for std
+#include <map>              // for map, map<>::mapped_type, _Rb_tree_iterator
+#include <memory>           // for allocator_traits<>::value_type
+#include <string>           // for string, basic_string, allocator, operator+
+#include <utility>          // for pair
+#include <vector>           // for vector
+#include "conversions.hpp"  // for hexdec
+#include "cssopt.hpp"       // for shorthand
+#include "datastruct.hpp"   // for token, css_struct, message, COMMENT, Info...
+#include "important.hpp"    // for is_important, gvw_important
+#include "misc.hpp"         // for ctype_space, ctype_xdigit, in_str_array
+#include "trim.hpp"         // for trim, rtrim
+#include "umap.hpp"         // for umap, umap<>::iterator
+
+using namespace std;
+
 extern map< string, vector<string> > shorthands;
 
 csstidy::csstidy()

--- a/csstidy/csstidy.hpp
+++ b/csstidy/csstidy.hpp
@@ -20,57 +20,62 @@
 #ifndef HEADER_CSSTIDY
 #define HEADER_CSSTIDY 
 
+#include <map>             // for map
+#include <string>          // for string, basic_string
+#include <vector>          // for vector
+#include "datastruct.hpp"  // for token, css_struct, message_type, token_type
+
 class csstidy 
 { 
 	public: 
-		int                        properties,selectors,input_size,output_size;
-		string                     charset,namesp, css_level;
-		vector<string>             import, csstemplate;
-		map<int, vector<message> > logs;
-		map<string, int>           settings;
+		int         properties,selectors,input_size,output_size;
+		std::string charset,namesp, css_level;
+		std::vector<std::string>             import, csstemplate;
+		std::map<int, std::vector<message> > logs;
+		std::map<std::string, int>           settings;
 	
 	private:
 		css_struct    css;
-		vector<token> csstokens;
-		string        tokens, cur_selector, cur_at, cur_property, cur_function, cur_sub_value, cur_value, cur_string;
+		std::vector<token> csstokens;
+		std::string        tokens, cur_selector, cur_at, cur_property, cur_function, cur_sub_value, cur_value, cur_string;
 		int           line;
-		vector<int>   sel_separate;
+		std::vector<int>   sel_separate;
 
-		void add_token(const token_type ttype, const string data, const bool force = false);
+		void add_token(const token_type ttype, const std::string data, const bool force = false);
 		void _convert_raw_css();
 		
 		// Add a message to the message log
-		void log(const string msg, const message_type type, int iline = 0);
+		void log(const std::string msg, const message_type type, int iline = 0);
 		
 		int _seeknocomment(const int key, const int move);
-		string _htmlsp(const string istring, const bool plain);
-		string optimise_subvalue(string subvalue, const string property, const string function);
+		std::string _htmlsp(const std::string istring, const bool plain);
+		std::string optimise_subvalue(std::string subvalue, const std::string property, const std::string function);
 		void explode_selectors();
 		
 		// Parses unicode notations
-		string unicode(string& istring,int& i);
+		std::string unicode(std::string& istring,int& i);
 		
 		// Checks if the chat in istring at i is a token
-		bool is_token(string& istring,const int i);
+		bool is_token(std::string& istring,const int i);
 						
 	public:
 	    csstidy();
 	    	
 		// Adds a property-value pair to an existing CSS structure
-		void add(const string& media, const string& selector, const string& property, const string& value);
-	    void copy(const string media, const string selector, const string media_new, const string selector_new);
+		void add(const std::string& media, const std::string& selector, const std::string& property, const std::string& value);
+	    void copy(const std::string media, const std::string selector, const std::string media_new, const std::string selector_new);
 	
 		// Prints CSS code
-		void print_css(string filename = "");
+		void print_css(std::string filename = "");
 		
 		// Parse a piece of CSS code
-		void parse_css(string css_input);
+		void parse_css(std::string css_input);
 		
 		/* Merges properties like margin */
-		void merge_4value_shorthands(string media, string selector);
+		void merge_4value_shorthands(std::string media, std::string selector);
 		
 		/* Dissolves properties like padding:10px 10px 10px to padding-top:10px;padding-bottom:10px;... */
-		map<string,string> dissolve_4value_shorthands(string property, string value);
+		std::map<std::string,std::string> dissolve_4value_shorthands(std::string property, std::string value);
 };
 	    
 #endif // HEADER_CSSTIDY

--- a/csstidy/datastruct.hpp
+++ b/csstidy/datastruct.hpp
@@ -17,13 +17,15 @@
  *   along with this program.  If not, see <http://www.gnu.org/licenses/>.
 */
  
-using namespace std;
-#ifndef HEADER_CSS_STRUCT 
-#define HEADER_CSS_STRUCT 
+#ifndef HEADER_CSS_STRUCT
+#define HEADER_CSS_STRUCT
 
-typedef umap<string, string>   pstore;
-typedef umap<string, pstore >  sstore;
-typedef umap<string, sstore>   css_struct;
+#include <string>  // for string
+#include "umap.hpp"
+
+typedef umap<std::string, std::string> pstore;
+typedef umap<std::string, pstore>      sstore;
+typedef umap<std::string, sstore>      css_struct;
 
 enum parse_status
 {
@@ -43,12 +45,12 @@ enum token_type
 struct token
 {
 	token_type type;
-	string data;
+	std::string data;
 };
 
 struct message
 {
-	string m;
+	std::string m;
 	message_type t;
 };
 

--- a/csstidy/file_functions.cpp
+++ b/csstidy/file_functions.cpp
@@ -17,7 +17,11 @@
  *   along with this program.  If not, see <http://www.gnu.org/licenses/>.
 */
 
-#include "csspp_globals.hpp"
+
+#include "file_functions.hpp"
+#include <string>
+#include <fstream>
+
 using namespace std;
 
 string file_get_contents(const string filename)

--- a/csstidy/file_functions.hpp
+++ b/csstidy/file_functions.hpp
@@ -20,8 +20,10 @@
 #ifndef HEADER_CSS_FILE
 #define HEADER_CSS_FILE 
 
+#include <string>
+
 // Get contents of a file
-string file_get_contents(const string filename);
+std::string file_get_contents(const std::string filename);
 
 // Checks if a file exists
 bool file_exists(const char *filename);

--- a/csstidy/important.cpp
+++ b/csstidy/important.cpp
@@ -17,7 +17,12 @@
  *   along with this program.  If not, see <http://www.gnu.org/licenses/>.
 */
 
-#include "csspp_globals.hpp"
+#include <iosfwd>           // for std
+#include <string>           // for string, operator==, operator+, basic_string
+#include "conversions.hpp"  // for strtolower
+#include "important.hpp"    // for c_important, gvw_important, is_important
+#include "trim.hpp"         // for trim, rtrim
+
 using namespace std;
 
 

--- a/csstidy/important.hpp
+++ b/csstidy/important.hpp
@@ -18,15 +18,17 @@
 */
  
 #ifndef HEADER_CSS_IMPORTANT
-#define HEADER_CSS_IMPORTANT 
+#define HEADER_CSS_IMPORTANT
+
+#include <string>  // for string
 
 // Checks if value is important
-bool is_important(string value);
+bool is_important(std::string value);
 
 // Get value without !important
-string gvw_important(string value);
+std::string gvw_important(std::string value);
 
 // Compresses !important (for example if someone uses "! important")
-string c_important(string value);
+std::string c_important(std::string value);
 
 #endif //HEADER_CSS_IMPORTANT 

--- a/csstidy/main.cpp
+++ b/csstidy/main.cpp
@@ -17,11 +17,41 @@
  *   along with this program.  If not, see <http://www.gnu.org/licenses/>.
 */
 
-using namespace std;
+#include <map>
+#include <string>
+#include <vector>
 
-#include "csspp_globals.hpp"
+#include <cstdlib>
+#include <string> 
+#include <iterator>
+#include <vector>
+#include <assert.h>
+#include <math.h>
+#include <time.h>
+#include <sstream>
+#include <iostream>
+#include <fstream>
+#include <map>
+#include <algorithm>
+
+#include "umap.hpp"
+#include "datastruct.hpp"
+ 
+#include "trim.hpp"
+#include "conversions.hpp"
+#include "misc.hpp"
+#include "important.hpp"
+#include "file_functions.hpp"
+ 
+#include "cssopt.hpp"
+#include "csstidy.hpp"
+ 
+#include "parse_css.hpp"
+#include "background.hpp"
 
 #include "prepare.hpp"
+
+using namespace std;
 
 map< string, vector<string> > predefined_templates;
 

--- a/csstidy/misc.cpp
+++ b/csstidy/misc.cpp
@@ -16,8 +16,17 @@
  *   You should have received a copy of the GNU Lesser General Public License
  *   along with this program.  If not, see <http://www.gnu.org/licenses/>.
 */
-#include <cstring> 
-#include "csspp_globals.hpp"
+
+#include "misc.hpp"
+#include <cmath>
+#include <cstring>             // for strchr, strlen, NULL
+#include <iosfwd>              // for std
+#include <memory>              // for allocator_traits<>::value_type
+#include <string>              // for string, basic_string, allocator, opera...
+#include <vector>              // for vector
+#include "conversions.hpp"     // for chartolower, f2str, str2f
+
+using namespace std;
 
 bool escaped(const string &istring, const int pos) 
 {
@@ -94,7 +103,7 @@ string build_value(const vector<string> subvalues)
 
 float round(const float &number, const int num_digits)
 {
-    float doComplete5i, doComplete5(number * powf(10.0f, (float) (num_digits + 1)));
+    float doComplete5i, doComplete5(number * std::pow(10.0f, (float) (num_digits + 1)));
     
     if(number < 0.0f)
         doComplete5 -= 5.0f;
@@ -102,9 +111,9 @@ float round(const float &number, const int num_digits)
         doComplete5 += 5.0f;
     
     doComplete5 /= 10.0f;
-    modff(doComplete5, &doComplete5i);
+    std::modf(doComplete5, &doComplete5i);
     
-    return doComplete5i / powf(10.0f, (float) num_digits);
+    return doComplete5i / std::pow(10.0f, (float) num_digits);
 }
 
 

--- a/csstidy/misc.hpp
+++ b/csstidy/misc.hpp
@@ -20,34 +20,37 @@
 #ifndef HEADER_CSS_MISC
 #define HEADER_CSS_MISC 
 
+#include <string>  // for string
+#include <vector>  // for vector
+
 // Checks if a charcter is escaped
-bool escaped(const string &istring, int pos);
+bool escaped(const std::string &istring, int pos);
 
 // Returns a char of a string at pos but checks the string-length before
-char s_at(const string &istring, int pos);
+char s_at(const std::string &istring, int pos);
 
 // Splits a string at e
-vector<string> explode(const string e, string s, const bool check = false);
+std::vector<std::string> explode(const std::string e, std::string s, const bool check = false);
 
 // Implodes a string at e
-std::string implode(const string e, const vector<string> s);
+std::string implode(const std::string e, const std::vector<std::string> s);
 
 // Builds a compact value string, inserting spaces only where necessary
-std::string build_value(const vector<string> subvalues);
+std::string build_value(const std::vector<std::string> subvalues);
 
 // Replaces <find> with <replace> in <str>
-string str_replace(const string find, const string replace, string str);
+std::string str_replace(const std::string find, const std::string replace, std::string str);
 
 // Replaces all values of <find> with <replace> in <str>
-string str_replace(const vector<string>& find, const string replace, string str);
+std::string str_replace(const std::vector<std::string>& find, const std::string replace, std::string str);
 
 // Checks if a string exists in a string-array
 bool in_char_arr(const char* haystack, const char needle);
-bool in_str_array(const string& haystack, const char needle);
-bool in_str_array(const vector<string>& haystack, const string needle);
+bool in_str_array(const std::string& haystack, const char needle);
+bool in_str_array(const std::vector<std::string>& haystack, const std::string needle);
 
 // Replaces certain chars with their entities
-string htmlspecialchars(string istring, int quotes = 0);
+std::string htmlspecialchars(std::string istring, int quotes = 0);
 
 // Rounds a float value
 float round(const float &number, const int num_digits);
@@ -62,9 +65,9 @@ bool ctype_xdigit(char c);
 bool ctype_alpha(char c);
 
 /* Unserialise string arrays */
-vector<string> unserialise_sa(const string istring);
+std::vector<std::string> unserialise_sa(const std::string istring);
 
 /* Serialise a string */
-string serialise_sa(const string istring);
+std::string serialise_sa(const std::string istring);
 
 #endif // HEADER_CSS_MISC

--- a/csstidy/parse_css.cpp
+++ b/csstidy/parse_css.cpp
@@ -17,7 +17,21 @@
  *   along with this program.  If not, see <http://www.gnu.org/licenses/>.
 */
 
-#include "csspp_globals.hpp"
+#include <assert.h>         // for assert
+#include <iosfwd>           // for std
+#include <map>              // for map, _Rb_tree_iterator, operator!=, map<>...
+#include <string>           // for string, allocator, operator+, basic_string
+#include <utility>          // for pair
+#include <vector>           // for vector, vector<>::reverse_iterator
+#include "background.hpp"   // for dissolve_short_bg, merge_bg
+#include "conversions.hpp"  // for strtolower, char2str, strtoupper
+#include "cssopt.hpp"       // for c_font_weight, compress_numbers, cut_color
+#include "csstidy.hpp"      // for csstidy
+#include "datastruct.hpp"   // for Warning, parse_status, is, css_struct
+#include "important.hpp"    // for c_important
+#include "misc.hpp"         // for s_at, ctype_space, escaped, build_value
+#include "trim.hpp"         // for trim
+#include "umap.hpp"         // for umap<>::iterator, umap
 
 using namespace std;
 

--- a/csstidy/prepare.cpp
+++ b/csstidy/prepare.cpp
@@ -17,7 +17,15 @@
  *   along with this program.  If not, see <http://www.gnu.org/licenses/>.
 */
 
-#include "csspp_globals.hpp"
+#include <fstream>         // for std
+#include <map>             // for map, map<>::mapped_type
+#include <string>          // for string, operator<, basic_string
+#include <sstream>
+#include <vector>          // for vector
+#include "datastruct.hpp"  // for parse_status, at, iv, is
+
+
+using namespace std;
 
 map<string,bool> settings;
 map< string, vector<string> > shorthands;

--- a/csstidy/print_css.cpp
+++ b/csstidy/print_css.cpp
@@ -17,7 +17,24 @@
  *   along with this program.  If not, see <http://www.gnu.org/licenses/>.
 */
 
-#include "csspp_globals.hpp"
+#include <cstdlib>             // for abs
+#include <ctime>               // for asctime, localtime, time, time_t
+#include <iostream>            // for operator<<
+#include <map>                 // for map, _Rb_tree_iterator, operator!=
+#include <memory>              // for allocator, allocator_traits<>::value_type
+#include <string>              // for operator<<, string, char_traits, basic...
+#include <sstream>             // for stringstream
+#include <fstream>             // for ofsream
+#include <utility>             // for pair
+#include <vector>              // for vector
+#include "conversions.hpp"     // for strtolower, strtoupper
+#include "csspp_globals.hpp"   // for CSSTIDY_VERSION
+#include "csstidy.hpp"         // for csstidy
+#include "datastruct.hpp"      // for token, css_struct, AT_END, COMMENT
+#include "misc.hpp"            // for round, str_replace, htmlspecialchars
+#include "trim.hpp"            // for rtrim, strip_tags, trim
+#include "umap.hpp"            // for umap<>::iterator, umap
+
 
 using namespace std;
 
@@ -63,7 +80,7 @@ void csstidy::_convert_raw_css()
 int csstidy::_seeknocomment(const int key, int move)
 {
     int go = (move > 0) ? 1 : -1;
-    for (int i = key + 1; abs(key-i)-1 < abs(move); i += go) {
+    for (int i = key + 1; std::abs(key-i)-1 < std::abs(move); i += go) {
         if (i < 0 || i >= csstokens.size()) {
             return -1;
         }

--- a/csstidy/trim.cpp
+++ b/csstidy/trim.cpp
@@ -17,7 +17,10 @@
  *   along with this program.  If not, see <http://www.gnu.org/licenses/>.
 */
  
-#include "csspp_globals.hpp"
+#include <iosfwd>    // for std
+#include <string>    // for string
+#include "trim.hpp"  // for rtrim, ltrim, strip_tags, trim
+
 using namespace std;
 
 const string trim(const string istring)

--- a/csstidy/trim.hpp
+++ b/csstidy/trim.hpp
@@ -20,17 +20,19 @@
 #ifndef HEADER_CSS_TRIM
 #define HEADER_CSS_TRIM 
 
+#include <string>    // for string
+
 // Removes whitespace at the end and beginning of a string
-const string trim(const string istring);
+const std::string trim(const std::string istring);
 
 // Removes whitespace at the beginning of a string
-const string ltrim(const string istring);
+const std::string ltrim(const std::string istring);
 
 // Removes whitespace at the end of a string
-const string rtrim(const string istring);
-const string rtrim(const string istring, const string chars);
+const std::string rtrim(const std::string istring);
+const std::string rtrim(const std::string istring, const std::string chars);
 
 // Removes HTML tags
-string strip_tags(string istring);
+std::string strip_tags(std::string istring);
 
 #endif // HEADER_CSS_TRIM

--- a/csstidy/umap.hpp
+++ b/csstidy/umap.hpp
@@ -17,6 +17,9 @@
  *   along with this program.  If not, see <http://www.gnu.org/licenses/>.
 */
 
+#ifndef HEADER_CSS_UMAP
+#define HEADER_CSS_UMAP
+
 #include <cstdlib>
 #include <iostream>
 #include <string>
@@ -24,13 +27,11 @@
 #include <map>
 #include <algorithm>
 #include <iterator>
-using namespace std;
-
 
 template <class keyT, class valT>
 class umap 
 { 
-	typedef map<keyT,valT> StoreT;
+	typedef std::map<keyT,valT> StoreT;
 	typedef std::vector<typename StoreT::iterator> FifoT;
 	private:
 		FifoT sortv;
@@ -80,7 +81,7 @@ class umap
 		{
 			sortv.clear();
 			content = set.content;
-			for(typename map<keyT,valT>::iterator i = content.begin(); i != content.end(); ++i)
+			for(typename std::map<keyT,valT>::iterator i = content.begin(); i != content.end(); ++i)
 			{
 				sortv.push_back(i);
 			}
@@ -201,3 +202,5 @@ class umap
 			return test;
 		}
 };
+
+#endif  // HEADER_CSS_UMAP


### PR DESCRIPTION
This PR is primarily the results of running [include-what-you-use](https://github.com/include-what-you-use/include-what-you-use) on the source, except where it made stupid decisions and I had to override it. Basically, it's an attempt to modernize the source's use of headers (both system and local).

As a consequence, the giant pile of headers in `csspp_globals.hpp` that was getting included into every source file is removed. (In fact, it now contains _only_ the version `#define`.) Header `#include`s are done at the point they're needed, in the files that need them.

Additionally:
- Eliminate `using namespace std;`, or reliance upon same, from all headers.
  (Because that is just **The. _Worst._**)
- Add a ton of `std::` prefixing in headers where needed, as a result of previous
- Add include guards to headers lacking them
- Rely less on functions from C headers (`math.h`, `stdlib.h`, etc.), preferring instead the `std::` equivalents from `<cmath>`, `<cstdlib>`...

The resulting tree still builds for me on Fedora 34 using either `g++` or `clang++`. I can't make any statements about Windows, though.
